### PR TITLE
renamed polygon constants, script, and Sheet

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -55,7 +55,7 @@ var constants = {
   _colorOpacity: 'Polygon Color Opacity',
   _outlineColor: 'Polygon Outline Color',
   _bucketColors: 'Property Range Manual Colors',
-  _polygonDisplayImages: 'Display Images When Available',
-  _polygonLabel: 'Display Polygon Labels at Zoom Level',
-  _polygonLabelMaxZoom: 'Maximum Zoom for Polygon Label',
+  _polygonDisplayImages: 'Show Images When Available',
+  _polygonLabel: 'Show Polygon Labels',
+  _polygonLabelZoomLevel: 'Show Polygon Labels at Zoom Level',
 };

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -1089,7 +1089,7 @@ $(window).on('load', function() {
    */
   function togglePolygonLabels() {
     for (i in allTextLabels) {
-      if (map.getZoom() <= tryPolygonSetting(i, '_polygonLabelMaxZoom', 9)) {
+      if (map.getZoom() <= tryPolygonSetting(i, '_polygonLabelZoomLevel', 9)) {
         $('.polygon-label' + i).hide();
       } else {
         if ($('.polygons-legend' + i + ' input[name=prop]:checked').val() != '-1') {


### PR DESCRIPTION
To make polygon settings easier for users to understand, I renamed three items in constants.js and Google Sheet, and also one in script.js

<img width="736" alt="leaflet_maps_with_google_sheets_development_-_google_sheets" src="https://cloud.githubusercontent.com/assets/649719/24838085/00620128-1d0f-11e7-9983-763a1cab3390.png">
